### PR TITLE
Bug fix: issue #20

### DIFF
--- a/src/core/ngx_core.h
+++ b/src/core/ngx_core.h
@@ -33,6 +33,7 @@ typedef void (*ngx_connection_handler_pt)(ngx_connection_t *c);
 #define  NGX_DONE       -4
 #define  NGX_DECLINED   -5
 #define  NGX_ABORT      -6
+#define  NGX_STOP       -7
 
 
 #include <ngx_errno.h>

--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -1915,7 +1915,7 @@ failed:
 
         case NGX_HTTP_UPSTREAM_DYN_RESOLVE_SHUTDOWN:
             ngx_http_upstream_finalize_request(r, u, NGX_HTTP_BAD_GATEWAY);
-            return NGX_DONE;
+            return NGX_STOP;
 
         default:
 
@@ -1989,7 +1989,7 @@ failed:
         return NGX_DECLINED;
     }
 
-    return NGX_DONE;
+    return NGX_STOP;
 }
 
 
@@ -2024,7 +2024,7 @@ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
     if (u->conf->dyn_resolve) {
         rc = ngx_http_upstream_connect_and_resolve_peer(&u->peer, r);
 
-        if (rc == NGX_DONE) {
+        if (rc == NGX_STOP) {
             return;
         }
     } else {


### PR DESCRIPTION
Fixed issue #20, which reported that if keepalive is enabled in an
upstream and dynamic resovle is also enabled, SEnginx worker will die due to
a segmentation fault caused by a "double free" error.

Fixed as:

1) use NGX_STOP to indicate to pause current request to wait for a DNS
query response. NGX_DONE is used by the upstream keepalive module to
connect to upstream server.

2) introduce new test cases to cover this scenario.

Signed-off-by: Paul Yang(InfoHunter) paulyang.inf@gmail.com
