### PR TITLE
Feature: add robot_mitigation_secret directive

### DIFF
--- a/neusoft/ngx_http_robot_mitigation/ngx_http_robot_mitigation.h
+++ b/neusoft/ngx_http_robot_mitigation/ngx_http_robot_mitigation.h
@@ -93,6 +93,7 @@ typedef struct {
     ngx_str_t                   cookie_name_c;
     ngx_str_t                   timeout_c;
     time_t                      timeout;
+    ngx_str_t                   secret;
 
     ngx_array_t                 *whitelist_items;
     ngx_array_t                 *ip_whitelist_items;


### PR DESCRIPTION
Use this directive to set a secret string to enhance robustness of the
challenge key, if this direcive is missing, SEnginx will pick a dynamic
secret each time on start. You can also use this directive to set a same
secret among some SEnginxes in a cluster to avoid "miss-match" problem
of robot mitigation.

Signed-off-by: Paul Yang(InfoHunter) paulyang.inf@gmail.com
